### PR TITLE
Add EmptyElement concept to HashBuilder

### DIFF
--- a/lib/saxerator.rb
+++ b/lib/saxerator.rb
@@ -8,9 +8,10 @@ require 'saxerator/document_fragment'
 require 'saxerator/configuration'
 
 require 'saxerator/builder'
-require 'saxerator/builder/string_element'
-require 'saxerator/builder/hash_element'
 require 'saxerator/builder/array_element'
+require 'saxerator/builder/empty_element'
+require 'saxerator/builder/hash_element'
+require 'saxerator/builder/string_element'
 require 'saxerator/builder/hash_builder'
 require 'saxerator/builder/xml_builder'
 

--- a/lib/saxerator/builder/empty_element.rb
+++ b/lib/saxerator/builder/empty_element.rb
@@ -1,0 +1,18 @@
+require 'saxerator/builder/hash_element'
+
+module Saxerator
+  module Builder
+    class EmptyElement < HashElement
+      def nil?; true end
+      def !; true end
+
+      def to_s
+        StringElement.new('', name, attributes)
+      end
+
+      def to_h
+        HashElement.new(name, attributes)
+      end
+    end
+  end
+end

--- a/lib/saxerator/builder/hash_builder.rb
+++ b/lib/saxerator/builder/hash_builder.rb
@@ -16,6 +16,10 @@ module Saxerator
         @children << node
       end
 
+      def to_empty_element
+        EmptyElement.new(@name, @attributes)
+      end
+
       def to_s
         StringElement.new(@children.join, @name, @attributes)
       end
@@ -27,14 +31,14 @@ module Saxerator
           name = child.name
           element = child.block_variable
 
-          add_to_hash_element( hash, name, element)
+          add_to_hash_element(hash, name, element)
         end
 
         if @config.put_attributes_in_hash?
 
           @attributes.each do |attribute|
             attribute.each_slice(2) do |name, element|
-              add_to_hash_element( hash, name, element)
+              add_to_hash_element(hash, name, element)
             end
           end
         end
@@ -56,7 +60,9 @@ module Saxerator
       end
 
       def block_variable
-        @text ? to_s : to_hash
+        return to_s if @text
+        return to_hash if @children.count > 0
+        to_empty_element
       end
     end
   end

--- a/spec/lib/builder/hash_builder_spec.rb
+++ b/spec/lib/builder/hash_builder_spec.rb
@@ -33,5 +33,26 @@ describe "Saxerator (default) hash format" do
   specify { entry['content'].should == "<p>Airplanes are very large — this can present difficulty in digestion.</p>" }
 
   # empty element
-  specify { entry['media:thumbnail'].should == {} }
+  context "parsing an empty element" do
+    subject(:element) { entry['media:thumbnail'] }
+
+    it "behaves somewhat like nil" do
+      element.should be_nil
+      (!element).should eq true
+      element.to_s.should eq ''
+      element.to_h.should eq Hash.new
+    end
+
+    it { should be_empty }
+
+    it "has attributes" do
+      element.attributes.keys.should eq ['url']
+    end
+
+    [:to_s, :to_h].each do |conversion|
+      it "preserves attributes through ##{conversion}" do
+        element.send(conversion).attributes.keys.should eq ['url']
+      end
+    end
+  end
 end


### PR DESCRIPTION
This should allow code dealing with sometimes-empty string-like elements to require less special casing.

Addresses #12 indirectly
