### PR TITLE
Convert specs to RSpec 3.0.0.beta2 syntax with Transpec

### DIFF
--- a/saxerator.gemspec
+++ b/saxerator.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'nokogiri', '>= 1.4.0'
 
-  s.add_development_dependency 'rspec', '>= 2.11.0'
+  s.add_development_dependency 'rspec', '>= 3.0.0.beta2'
 end

--- a/spec/lib/builder/hash_builder_spec.rb
+++ b/spec/lib/builder/hash_builder_spec.rb
@@ -6,87 +6,87 @@ describe "Saxerator (default) hash format" do
   subject(:entry) { Saxerator.parser(xml).for_tag(:entry).first }
 
   # string
-  specify { entry['title'].should == 'How to eat an airplane' }
+  specify { expect(entry['title']).to eq('How to eat an airplane') }
 
   # hash and cdata inside name
-  specify { entry['author'].should == {'name' => 'Soul<utter'} }
+  specify { expect(entry['author']).to eq({'name' => 'Soul<utter'}) }
 
   # array of hashes
-  specify { entry['contributor'].should == [{'name' => 'Jane Doe'}, {'name' => 'Leviticus Alabaster'}] }
+  specify { expect(entry['contributor']).to eq([{'name' => 'Jane Doe'}, {'name' => 'Leviticus Alabaster'}]) }
 
   # attributes on a hash
-  specify { entry['contributor'][0].attributes['type'].should == 'primary' }
+  specify { expect(entry['contributor'][0].attributes['type']).to eq('primary') }
 
   # attributes on a string
-  specify { entry['content'].attributes['type'].should == 'html' }
+  specify { expect(entry['content'].attributes['type']).to eq('html') }
 
   # name on a hash
-  specify { entry.name.should == 'entry' }
+  specify { expect(entry.name).to eq('entry') }
 
   # name on a string
-  specify { entry['title'].name.should == 'title' }
+  specify { expect(entry['title'].name).to eq('title') }
 
   describe "#to_s" do
     it "preserves the element name" do
-      entry['title'].to_a.name.should == 'title'
+      expect(entry['title'].to_a.name).to eq('title')
     end
   end
 
   describe "#to_h" do
     it "preserves the element name" do
-      entry.to_h.name.should == 'entry'
+      expect(entry.to_h.name).to eq('entry')
     end
   end
 
   describe "#to_a" do
     it "preserves the element name on a parsed hash" do
-      entry.to_a.name.should == 'entry'
+      expect(entry.to_a.name).to eq('entry')
     end
 
     it "converts parsed hashes to nested key/value pairs (just like regular hashes)" do
-      entry.to_a.first.should == ['id', '1']
+      expect(entry.to_a.first).to eq(['id', '1'])
     end
 
     it "preserves the element name on a parsed string" do
-      entry['title'].to_a.name.should == 'title'
+      expect(entry['title'].to_a.name).to eq('title')
     end
 
     it "preserves the element name on an array" do
-      entry['contributor'].to_a.name.should eq 'contributor'
+      expect(entry['contributor'].to_a.name).to eq 'contributor'
     end
   end
 
   # name on an array
-  specify { entry['contributor'].name.should == 'contributor' }
+  specify { expect(entry['contributor'].name).to eq('contributor') }
 
   # character entity decoding
-  specify { entry['content'].should == "<p>Airplanes are very large — this can present difficulty in digestion.</p>" }
+  specify { expect(entry['content']).to eq("<p>Airplanes are very large — this can present difficulty in digestion.</p>") }
 
   context "parsing an empty element" do
     subject(:element) { entry['media:thumbnail'] }
 
     it "behaves somewhat like nil" do
-      element.should be_nil
-      (!element).should eq true
-      element.to_s.should eq ''
-      element.to_h.should eq Hash.new
+      expect(element).to be_nil
+      expect(!element).to eq true
+      expect(element.to_s).to eq ''
+      expect(element.to_h).to eq Hash.new
     end
 
-    it { should be_empty }
+    it { is_expected.to be_empty }
 
     it "has attributes" do
-      element.attributes.keys.should eq ['url']
+      expect(element.attributes.keys).to eq ['url']
     end
 
     [:to_s, :to_h, :to_a].each do |conversion|
       it "preserves the element name through ##{conversion}" do
-        element.send(conversion).name.should eq 'media:thumbnail'
+        expect(element.send(conversion).name).to eq 'media:thumbnail'
       end
     end
 
     [:to_s, :to_h].each do |conversion|
       it "preserves attributes through ##{conversion}" do
-        element.send(conversion).attributes.keys.should eq ['url']
+        expect(element.send(conversion).attributes.keys).to eq ['url']
       end
     end
   end

--- a/spec/lib/builder/xml_builder_spec.rb
+++ b/spec/lib/builder/xml_builder_spec.rb
@@ -9,7 +9,7 @@ describe "Saxerator xml format" do
     end.for_tag(:entry).first
   end
 
-  it { should be_a(Nokogiri::XML::Node) }
+  it { is_expected.to be_a(Nokogiri::XML::Node) }
   it "looks like the original document" do
     expected_xml = <<-eos
 <?xml version="1.0"?>
@@ -32,6 +32,6 @@ describe "Saxerator xml format" do
   </contributor>
 </entry>
     eos
-    entry.to_xml.should == expected_xml
+    expect(entry.to_xml).to eq(expected_xml)
   end
 end

--- a/spec/lib/dsl/all_spec.rb
+++ b/spec/lib/dsl/all_spec.rb
@@ -15,7 +15,7 @@ describe "Saxerator::FullDocument#all" do
   end
 
   it "should allow you to parse an entire document" do
-    parser.all.should == {'blurb' => ['one', 'two', 'three'], 'notablurb' => 'four'}
+    expect(parser.all).to eq({'blurb' => ['one', 'two', 'three'], 'notablurb' => 'four'})
   end
   
   context "with_put_attributes_in_hash" do
@@ -24,7 +24,7 @@ describe "Saxerator::FullDocument#all" do
     end
         
     it "should allow you to parse an entire document" do
-      parser.all.should == {'blurb' => ['one', 'two', 'three'], 'notablurb' => 'four'}
+      expect(parser.all).to eq({'blurb' => ['one', 'two', 'three'], 'notablurb' => 'four'})
     end
   end
   

--- a/spec/lib/dsl/at_depth_spec.rb
+++ b/spec/lib/dsl/at_depth_spec.rb
@@ -19,16 +19,16 @@ describe "Saxerator::DSL#at_depth" do
   end
 
   it "should parse elements at the requested tag depth" do
-    parser.at_depth(2).inject([], :<<).should == [
+    expect(parser.at_depth(2).inject([], :<<)).to eq([
       'How to eat an airplane', 'Leviticus Alabaster',
       'To wallop a horse in the face', 'Jeanne Clarewood'
-    ]
+    ])
   end
 
   it "should work in combination with #for_tag" do
-    parser.at_depth(2).for_tag(:name).inject([], :<<).should == [
+    expect(parser.at_depth(2).for_tag(:name).inject([], :<<)).to eq([
         'How to eat an airplane',
         'To wallop a horse in the face'
-    ]
+    ])
   end
 end

--- a/spec/lib/dsl/child_of_spec.rb
+++ b/spec/lib/dsl/child_of_spec.rb
@@ -21,16 +21,16 @@ describe "Saxerator::DSL#child_of" do
   end
 
   it "should only parse children of the specified tag" do
-    parser.child_of(:grandchildren).inject([], :<<).should == [
+    expect(parser.child_of(:grandchildren).inject([], :<<)).to eq([
         'Mildred Marston'
-    ]
+    ])
   end
 
   it "should work in combination with #for_tag" do
-    parser.for_tag(:name).child_of(:children).inject([], :<<).should == [
+    expect(parser.for_tag(:name).child_of(:children).inject([], :<<)).to eq([
         'Rudy McMannis',
         'Tom McMannis',
         'Anne Welsh'
-    ]
+    ])
   end
 end

--- a/spec/lib/dsl/for_tag_spec.rb
+++ b/spec/lib/dsl/for_tag_spec.rb
@@ -15,6 +15,6 @@ describe "Saxerator::DSL#for_tag" do
   end
 
   it "should only select the specified tag" do
-    parser.for_tag(:blurb).inject([], :<<).should == ['one', 'two', 'three']
+    expect(parser.for_tag(:blurb).inject([], :<<)).to eq(['one', 'two', 'three'])
   end
 end

--- a/spec/lib/dsl/for_tags_spec.rb
+++ b/spec/lib/dsl/for_tags_spec.rb
@@ -14,10 +14,10 @@ describe "Saxerator::DSL#for_tags" do
   end
 
   it "should only select the specified tags" do
-    parser.for_tags(%w(blurb1 blurb3)).inject([], :<<).should == ['one', 'three']
+    expect(parser.for_tags(%w(blurb1 blurb3)).inject([], :<<)).to eq(['one', 'three'])
   end
 
   it "raises an ArgumentError for a non-Array argument" do
-    lambda { parser.for_tags("asdf") }.should raise_error ArgumentError
+    expect { parser.for_tags("asdf") }.to raise_error ArgumentError
   end
 end

--- a/spec/lib/dsl/with_attribute_spec.rb
+++ b/spec/lib/dsl/with_attribute_spec.rb
@@ -16,13 +16,13 @@ describe "Saxerator::DSL#with_attribute" do
   end
 
   it "should match tags with the specified attributes" do
-    subject.with_attribute(:type).inject([], :<<).should == [
+    expect(subject.with_attribute(:type).inject([], :<<)).to eq([
         'Leviticus Alabaster',
         'Eunice Diesel'
-    ]
+    ])
   end
 
   it "should match tags with the specified attributes" do
-    subject.with_attribute(:type, :primary).inject([], :<<).should == ['Leviticus Alabaster']
+    expect(subject.with_attribute(:type, :primary).inject([], :<<)).to eq(['Leviticus Alabaster'])
   end
 end

--- a/spec/lib/dsl/with_attributes_spec.rb
+++ b/spec/lib/dsl/with_attributes_spec.rb
@@ -17,16 +17,16 @@ describe "Saxerator::DSL#with_attributes" do
   end
 
   it "matches tags with the exact specified attributes" do
-    parser.with_attributes(:type => :primary, :ridiculous => 'true').inject([], :<<).should == [
+    expect(parser.with_attributes(:type => :primary, :ridiculous => 'true').inject([], :<<)).to eq([
         'Leviticus Alabaster'
-    ]
+    ])
   end
 
   it "matches tags which have the specified attributes" do
-    parser.with_attributes(%w(type ridiculous)).inject([], :<<).should == ['Leviticus Alabaster', 'Eunice Diesel']
+    expect(parser.with_attributes(%w(type ridiculous)).inject([], :<<)).to eq(['Leviticus Alabaster', 'Eunice Diesel'])
   end
 
   it "raises ArgumentError if you pass something other than a Hash or Array" do
-    lambda { parser.with_attributes('asdf') }.should raise_error ArgumentError
+    expect { parser.with_attributes('asdf') }.to raise_error ArgumentError
   end
 end

--- a/spec/lib/dsl/within_spec.rb
+++ b/spec/lib/dsl/within_spec.rb
@@ -16,13 +16,13 @@ describe "Saxerator::DSL#within" do
   end
 
   it "should only parse elements nested within the specified tag" do
-    parser.within(:article).inject([], :<<).should == [
+    expect(parser.within(:article).inject([], :<<)).to eq([
         'Is our children learning?',
         'Hazel Nutt'
-    ]
+    ])
   end
 
   it "should work in combination with #for_tag" do
-    parser.for_tag(:name).within(:article).inject([], :<<).should == ['Is our children learning?']
+    expect(parser.for_tag(:name).within(:article).inject([], :<<)).to eq(['Is our children learning?'])
   end
 end

--- a/spec/lib/saxerator_spec.rb
+++ b/spec/lib/saxerator_spec.rb
@@ -10,14 +10,14 @@ describe Saxerator do
       let(:xml) { fixture_file('flat_blurbs.xml') }
 
       it "should be able to parse it" do
-        parser.all.should == {'blurb' => ['one', 'two', 'three']}
+        expect(parser.all).to eq({'blurb' => ['one', 'two', 'three']})
       end
 
       it "should allow multiple operations on the same parser" do
         # This exposes a bug where if a File is not reset only the first
         # Enumerable method works as expected
-        parser.for_tag(:blurb).first.should == 'one'
-        parser.for_tag(:blurb).first.should == 'one'
+        expect(parser.for_tag(:blurb).first).to eq('one')
+        expect(parser.for_tag(:blurb).first).to eq('one')
       end
     end
 
@@ -32,7 +32,7 @@ describe Saxerator do
       end
 
       it "should be able to parse it" do
-        parser.all.should == { 'name' => 'Illiterates that can read', 'author' => 'Eunice Diesel' }
+        expect(parser.all).to eq({ 'name' => 'Illiterates that can read', 'author' => 'Eunice Diesel' })
       end
     end
   end
@@ -47,7 +47,7 @@ describe Saxerator do
 
       context "with config.output_type = :hash" do
         let(:output_type) { :hash }
-        specify { parser.all.should == {'bar' => 'baz'} }
+        specify { expect(parser.all).to eq({'bar' => 'baz'}) }
       end
 
       context "with an invalid config.output_type" do
@@ -61,8 +61,8 @@ describe Saxerator do
         Saxerator.parser(xml) { |config| config.symbolize_keys! }
       end
 
-      specify { parser.all.should == { :bar => 'baz' } }
-      specify { parser.all.name.should == :foo }
+      specify { expect(parser.all).to eq({ :bar => 'baz' }) }
+      specify { expect(parser.all.name).to eq(:foo) }
     end
 
     context "with ignore namespaces" do
@@ -85,7 +85,7 @@ describe Saxerator do
         parser.for_tag("bar").each do |tag|
           bar_count += 1
         end
-        bar_count.should == 2
+        expect(bar_count).to eq(2)
       }
     end
 
@@ -95,8 +95,8 @@ describe Saxerator do
         Saxerator.parser(xml) { |config| config.strip_namespaces! }
       end
 
-      specify { parser.all.should == {'bar' => 'baz'} }
-      specify { parser.all.name.should == 'foo' }
+      specify { expect(parser.all).to eq({'bar' => 'baz'}) }
+      specify { expect(parser.all.name).to eq('foo') }
 
       context "combined with symbolize keys" do
         subject(:parser) do
@@ -106,7 +106,7 @@ describe Saxerator do
           end
         end
 
-        specify { parser.all.should == {:bar => 'baz'} }
+        specify { expect(parser.all).to eq({:bar => 'baz'}) }
       end
 
       context "for specific namespaces" do
@@ -122,8 +122,8 @@ describe Saxerator do
           Saxerator.parser(xml) { |config| config.strip_namespaces! :ns1, :ns3 }
         end
 
-        specify { parser.all.should == {'ns2:bar' => 'baz', 'bar' => 'biz'} }
-        specify { parser.all.name.should == 'foo' }
+        specify { expect(parser.all).to eq({'ns2:bar' => 'baz', 'bar' => 'biz'}) }
+        specify { expect(parser.all.name).to eq('foo') }
       end
     end
 
@@ -139,7 +139,7 @@ describe Saxerator do
     end
 
     it "should be able to parse it" do
-      parser.all.should == { 'bar' => 'baz', 'foo' => 'bar' }
+      expect(parser.all).to eq({ 'bar' => 'baz', 'foo' => 'bar' })
     end
 
   end


### PR DESCRIPTION
This conversion is done by Transpec 1.10.4 with the following command:
    transpec
- 51 conversions
  from: obj.should
    to: expect(obj).to
- 43 conversions
  from: == expected
    to: eq(expected)
- 2 conversions
  from: it { should ... }
    to: it { is_expected.to ... }
- 2 conversions
  from: lambda { }.should
    to: expect { }.to
