### PR TITLE
Add attributes in empty tags

### DIFF
--- a/lib/saxerator/builder/hash_builder.rb
+++ b/lib/saxerator/builder/hash_builder.rb
@@ -35,7 +35,6 @@ module Saxerator
         end
 
         if @config.put_attributes_in_hash?
-
           @attributes.each do |attribute|
             attribute.each_slice(2) do |name, element|
               add_to_hash_element(hash, name, element)
@@ -61,7 +60,7 @@ module Saxerator
 
       def block_variable
         return to_s if @text
-        return to_hash if @children.count > 0
+        return to_hash if @children.count > 0 || (@attributes.count > 0 && @config.put_attributes_in_hash?)
         to_empty_element
       end
     end

--- a/spec/lib/dsl/all_spec.rb
+++ b/spec/lib/dsl/all_spec.rb
@@ -10,22 +10,22 @@ describe "Saxerator::FullDocument#all" do
         <blurb>two</blurb>
         <blurb>three</blurb>
         <notablurb>four</notablurb>
+        <empty with="attribute"/>
       </blurbs>
     eos
   end
 
   it "should allow you to parse an entire document" do
-    parser.all.should == {'blurb' => ['one', 'two', 'three'], 'notablurb' => 'four'}
+    parser.all.should == {'blurb' => ['one', 'two', 'three'], 'notablurb' => 'four', 'empty' => {} }
   end
-  
+
   context "with_put_attributes_in_hash" do
     subject(:parser) do
       Saxerator.parser(xml) { |config| config.put_attributes_in_hash! }
     end
-        
+
     it "should allow you to parse an entire document" do
-      parser.all.should == {'blurb' => ['one', 'two', 'three'], 'notablurb' => 'four'}
+      parser.all.should == {'blurb' => ['one', 'two', 'three'], 'notablurb' => 'four', 'empty' => { "with" => "attribute"}}
     end
   end
-  
 end


### PR DESCRIPTION
This is a quick fix for the problem in #17.

The main problem here though is, that tags with attributes and no children are handled as `EmptyElement`. If you change the handling of EmptyElements (merge attributes in it) existing tests break.

So I don't really know how to fix this on a global level. I guess the term "Empty Element" needs to be better defined
