### PR TITLE
Allow to init Saxerator::Builder::HashElement without arguments

### DIFF
--- a/lib/saxerator/builder/hash_element.rb
+++ b/lib/saxerator/builder/hash_element.rb
@@ -6,7 +6,7 @@ module Saxerator
       attr_accessor :attributes
       attr_accessor :name
 
-      def initialize(name, attributes)
+      def initialize(name = nil, attributes = nil)
         self.name = name
         self.attributes = attributes
       end


### PR DESCRIPTION
Hi, 

There is a rare case with [serialize](http://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html) method from `ActiveRecord`. 
When I'm trying to use `Saxerator::Builder::HashElement` through this serialization it raises an error about wrong number of arguments (0 for 2). 

Can we save the same `initialize` method's behavior as a behavior of parent class? 
To be able to use `Saxerator::Builder::HashElement.new` like `Hash.new`