### PR TITLE
Updated configuration class for check output_type for different adapters. Cosmetic changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ coverage/
 .rvmrc
 .ruby-version
 .ruby-gemset
+
+/spec/examples.txt

--- a/benchmark/benchmark.rb
+++ b/benchmark/benchmark.rb
@@ -3,21 +3,63 @@ require 'saxerator'
 require 'benchmark'
 
 file = ARGV.shift
-if !File.exists?(file)
+unless File.exists?(file)
   puts "Cannot find file #{file}"
   exit 1
 end
 file = File.new(file)
 
-count = count2 = count3 = count4 = 0
-Benchmark.bm do |x|
-  x.report('for_tag') { Saxerator.parser(file).for_tag(:artist).each { count = count + 1 } }
-  x.report('at_depth') { Saxerator.parser(file).at_depth(2).each { count2 = count2 + 1 } }
-  x.report('within') { Saxerator.parser(file).within(:artists).each { count3 = count3 + 1 } }
-  x.report('composite') { Saxerator.parser(file).for_tag(:name).within(:artist).at_depth(3).each { count4 = count4 + 1} }
+ADAPTERS = [:nokogiri, :ox].freeze
+
+class SaxeratorBenchmark
+  def initialize(file)
+    @file = file
+  end
+
+  def with_adapter(adapter)
+    puts '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@'
+    puts
+    puts "Benchmark with :#{adapter} parser"
+    puts
+    puts '@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@'
+    puts
+
+    count = count2 = count3 = count4 = 0
+
+    Benchmark.bm do |x|
+      x.report('for_tag') do
+        Saxerator.parser(@file) { |confing| confing.adapter = adapter }
+                 .for_tag(:artist).each { count += 1 }
+      end
+
+      x.report('at_depth') do
+        Saxerator.parser(@file) { |confing| confing.adapter = adapter }
+                 .at_depth(2).each { count2 += 1 }
+      end
+
+      x.report('within') do
+        Saxerator.parser(@file) { |confing| confing.adapter = adapter }
+                 .within(:artists).each { count3 += 1 }
+      end
+
+      x.report('composite') do
+        Saxerator.parser(@file) { |confing| confing.adapter = adapter }
+                 .for_tag(:name)
+                 .within(:artist).at_depth(3).each { count4 += 1 }
+      end
+    end
+
+    puts
+    puts '##########################################################'
+    puts
+    puts "for_tag:   #{count} artist elements parsed"
+    puts "at_depth:  #{count2} elements parsed"
+    puts "within:    #{count3} artists children parsed"
+    puts "composite: #{count4} names within artist nested 3 tags deep parsed"
+    puts
+  end
 end
 
-puts "for_tag:   #{count} artist elements parsed"
-puts "at_depth:  #{count2} elements parsed"
-puts "within:    #{count3} artists children parsed"
-puts "composite: #{count4} names within artist nested 3 tags deep parsed"
+saxerator_benchmark = SaxeratorBenchmark.new(file)
+
+ADAPTERS.each { |adapter| saxerator_benchmark.with_adapter(adapter) }

--- a/lib/saxerator/adapters/ox.rb
+++ b/lib/saxerator/adapters/ox.rb
@@ -1,0 +1,69 @@
+require 'forwardable'
+require 'ox'
+
+module Saxerator
+  module Adapters
+    class Ox # < ::Ox::Sax
+      extend Forwardable
+
+      def self.parse(source, reader)
+        handler = new(reader)
+        ::Ox.sax_parse(handler, source)
+      end
+
+      attr_accessor :name
+      attr_reader :attributes
+      attr_reader :reader
+
+      def initialize(reader)
+        @reader = reader
+
+        @attributes = Hash.new
+        @name = ''
+      end
+
+      def guard!
+        if name.length > 0
+          reader.start_element(name, attributes.to_a)
+        end
+        reset!
+      end
+
+      def attr(name, value)
+        attributes[name.to_s] = value
+      end
+
+      def start_element(name)
+        guard!
+
+        name = name.to_s
+        name = strip_namespace(name) if reader.ignore_namespaces?
+        self.name = name
+      end
+
+      def end_element(name)
+        guard!
+
+        name = name.to_s
+        name = strip_namespace(name) if reader.ignore_namespaces?
+        reader.end_element(name)
+      end
+
+      def text(str)
+        guard!
+        reader.characters(str)
+      end
+
+      private
+
+      def reset!
+        @attributes.clear
+        @name = ''
+      end
+
+      def strip_namespace(name)
+        name.split(":").last
+      end
+    end
+  end
+end

--- a/lib/saxerator/configuration.rb
+++ b/lib/saxerator/configuration.rb
@@ -25,9 +25,9 @@ module Saxerator
     end
 
     def output_type=(val)
-      raise_exeption("Unknown output_type '#{val.inspect}'") unless Builder.valid?(val)
+      raise ArgumentError.new("Unknown output_type '#{val.inspect}'") unless Builder.valid?(val)
       unless ALLOWED_OUTPUT_TYPES[@adapter].include?(val)
-        raise_exeption("Adapter '#{adapter.inspect}' not allow to use output_type '#{val.inspect}'")
+        raise ArgumentError.new("Adapter '#{adapter.inspect}' not allow to use output_type '#{val.inspect}'")
       end
 
       @output_type = val
@@ -78,14 +78,8 @@ module Saxerator
 
     def raise_error_if_using_put_attributes_in_hash_with_xml
       if @output_type != :hash && @put_attributes_in_hash
-        raise_exeption("put_attributes_in_hash! is only valid when using output_type = :hash (the default)'")
+        raise ArgumentError.new("put_attributes_in_hash! is only valid when using output_type = :hash (the default)'")
       end
-    end
-
-    private
-
-    def raise_exeption(text)
-      raise ArgumentError, text
     end
   end
 end

--- a/lib/saxerator/configuration.rb
+++ b/lib/saxerator/configuration.rb
@@ -3,6 +3,11 @@ module Saxerator
     attr_reader :output_type
     attr_writer :hash_key_generator
 
+    ALLOWED_OUTPUT_TYPES = {
+      nokogiri: [:hash, :xml],
+      ox: [:hash]
+    }.freeze
+
     def initialize
       @adapter = :nokogiri
       @output_type = :hash
@@ -20,7 +25,11 @@ module Saxerator
     end
 
     def output_type=(val)
-      raise ArgumentError.new("Unknown output_type '#{val.inspect}'") unless Builder.valid?(val)
+      raise_exeption("Unknown output_type '#{val.inspect}'") unless Builder.valid?(val)
+      unless ALLOWED_OUTPUT_TYPES[@adapter].include?(val)
+        raise_exeption("Adapter '#{adapter.inspect}' not allow to use output_type '#{val.inspect}'")
+      end
+
       @output_type = val
       raise_error_if_using_put_attributes_in_hash_with_xml
     end
@@ -69,8 +78,14 @@ module Saxerator
 
     def raise_error_if_using_put_attributes_in_hash_with_xml
       if @output_type != :hash && @put_attributes_in_hash
-        raise ArgumentError.new("put_attributes_in_hash! is only valid when using output_type = :hash (the default)'")
+        raise_exeption("put_attributes_in_hash! is only valid when using output_type = :hash (the default)'")
       end
+    end
+
+    private
+
+    def raise_exeption(text)
+      raise ArgumentError, text
     end
   end
 end

--- a/saxerator.gemspec
+++ b/saxerator.gemspec
@@ -33,7 +33,8 @@ Gem::Specification.new do |s|
   s.executables   = []
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'nokogiri', '>= 1.4.0'
+  s.add_development_dependency 'nokogiri', '>= 1.4.0'
+  s.add_development_dependency 'ox'
 
   s.add_development_dependency 'rspec', '~> 3.1'
 end

--- a/spec/lib/saxerator_spec.rb
+++ b/spec/lib/saxerator_spec.rb
@@ -2,185 +2,210 @@
 
 require 'spec_helper'
 
-describe Saxerator do
-  context "#parser" do
-    subject(:parser) { Saxerator.parser(xml) }
-
-    context "with a File argument" do
-      let(:xml) { fixture_file('flat_blurbs.xml') }
-
-      it "should be able to parse it" do
-        expect(parser.all).to eq({'blurb' => ['one', 'two', 'three']})
+RSpec.shared_examples_for Saxerator do |adapter|
+  describe "(#{adapter}): Saxerator" do
+    context "#parser" do
+      subject(:parser) do
+        Saxerator.parser(xml) do |config|
+          config.adapter = adapter
+        end
       end
 
-      it "should allow multiple operations on the same parser" do
-        # This exposes a bug where if a File is not reset only the first
-        # Enumerable method works as expected
-        expect(parser.for_tag(:blurb).first).to eq('one')
-        expect(parser.for_tag(:blurb).first).to eq('one')
-      end
-    end
+      context "with a File argument" do
+        let(:xml) { fixture_file('flat_blurbs.xml') }
 
-    context "with a String argument" do
-      let(:xml) do
-        <<-eos
+        it "should be able to parse it" do
+          expect(parser.all).to eq({'blurb' => ['one', 'two', 'three']})
+        end
+
+        it "should allow multiple operations on the same parser" do
+          # This exposes a bug where if a File is not reset only the first
+          # Enumerable method works as expected
+          expect(parser.for_tag(:blurb).first).to eq('one')
+          expect(parser.for_tag(:blurb).first).to eq('one')
+        end
+      end
+
+      context "with a String argument" do
+        let(:xml) do
+          <<-eos
           <book>
             <name>Illiterates that can read</name>
             <author>Eunice Diesel</author>
           </book>
-        eos
-      end
-
-      it "should be able to parse it" do
-        expect(parser.all).to eq({ 'name' => 'Illiterates that can read', 'author' => 'Eunice Diesel' })
-      end
-    end
-  end
-
-  context "configuration" do
-    let(:xml) { '<foo><bar foo="bar">baz</bar></foo>' }
-
-    context "output type" do
-      subject(:parser) do
-        Saxerator.parser(xml) { |config| config.output_type = output_type }
-      end
-
-      context "with config.output_type = :hash" do
-        let(:output_type) { :hash }
-        specify { expect(parser.all).to eq('bar' => 'baz') }
-      end
-
-      context "with config.output_type = :xml" do
-        let(:output_type) { :xml }
-        specify { expect(parser.all).to be_a Nokogiri::XML::Document }
-        specify { expect(parser.all.to_s).to include '<bar foo="bar">' }
-      end
-
-      context "with an invalid config.output_type" do
-        let(:output_type) { 'lmao' }
-        specify { expect { parser }.to raise_error(ArgumentError) }
-      end
-    end
-
-    context "symbolize keys" do
-      subject(:parser) do
-        Saxerator.parser(xml) do |config|
-          config.symbolize_keys!
-          config.output_type = :hash
+          eos
         end
-      end
 
-      specify { expect(parser.all).to eq(:bar => 'baz') }
-      specify { expect(parser.all.name).to eq(:foo) }
-
-      it 'will symbolize attributes' do
-        parser.for_tag('bar').each do |tag|
-          expect(tag.attributes).to include(:foo => 'bar')
+        it "should be able to parse it" do
+          expect(parser.all).to eq({ 'name' => 'Illiterates that can read', 'author' => 'Eunice Diesel' })
         end
       end
     end
 
-    context "with ignore namespaces" do
-      let(:xml) { <<-eos
+    context "configuration" do
+      let(:xml) { '<foo><bar foo="bar">baz</bar></foo>' }
+
+      context "output type" do
+        subject(:parser) do
+          Saxerator.parser(xml) do |config|
+            config.adapter = adapter
+            config.output_type = output_type
+          end
+        end
+
+        context "with config.output_type = :hash" do
+          let(:output_type) { :hash }
+          specify { expect(parser.all).to eq('bar' => 'baz') }
+        end
+
+        context "with config.output_type = :xml" do
+          let(:output_type) { :xml }
+          specify { expect(parser.all).to be_a Nokogiri::XML::Document }
+          specify { expect(parser.all.to_s).to include '<bar foo="bar">' }
+        end
+
+        context "with an invalid config.output_type" do
+          let(:output_type) { 'lmao' }
+          specify { expect { parser }.to raise_error(ArgumentError) }
+        end
+      end
+
+      context "symbolize keys" do
+        subject(:parser) do
+          Saxerator.parser(xml) do |config|
+            config.symbolize_keys!
+            config.output_type = :hash
+          end
+        end
+
+        specify { expect(parser.all).to eq(:bar => 'baz') }
+        specify { expect(parser.all.name).to eq(:foo) }
+
+        it 'will symbolize attributes' do
+          parser.for_tag('bar').each do |tag|
+            expect(tag.attributes).to include(:foo => 'bar')
+          end
+        end
+      end
+
+      context "with ignore namespaces" do
+        let(:xml) { <<-eos
 <ns1:foo xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ns1="http://foo.com" xmlns:ns3="http://bar.com">
   <ns3:bar>baz</ns3:bar>
   <ns3:bar bar="bar" ns1:foo="foo" class="class">bax</ns3:bar>
 </ns1:foo>
- eos
-}
-
-      subject(:parser) do
-        Saxerator.parser(xml) { |config|
-          config.ignore_namespaces!
+        eos
         }
-      end
 
-      specify {
-        bar_count = 0
-        parser.for_tag("bar").each do |tag|
-          bar_count += 1
-        end
-        expect(bar_count).to eq(2)
-      }
-    end
-
-    context "with strip namespaces" do
-      let(:xml) { "<ns1:foo><ns3:bar>baz</ns3:bar></ns1:foo>" }
-      subject(:parser) do
-        Saxerator.parser(xml) { |config| config.strip_namespaces! }
-      end
-
-      specify { expect(parser.all).to eq({'bar' => 'baz'}) }
-      specify { expect(parser.all.name).to eq('foo') }
-
-      context "combined with symbolize keys" do
         subject(:parser) do
           Saxerator.parser(xml) do |config|
-            config.strip_namespaces!
-            config.symbolize_keys!
+            config.adapter = adapter
+            config.ignore_namespaces!
           end
         end
 
-        specify { expect(parser.all).to eq({:bar => 'baz'}) }
+        specify {
+          bar_count = 0
+          parser.for_tag("bar").each do |tag|
+            bar_count += 1
+          end
+          expect(bar_count).to eq(2)
+        }
       end
 
-      context "for specific namespaces" do
-        let(:xml) do
-          <<-XML.gsub /^ {10}/, ''
+      context "with strip namespaces" do
+        let(:xml) { "<ns1:foo><ns3:bar>baz</ns3:bar></ns1:foo>" }
+        subject(:parser) do
+          Saxerator.parser(xml) do |config|
+            config.adapter = adapter
+            config.strip_namespaces!
+          end
+        end
+
+        specify { expect(parser.all).to eq({'bar' => 'baz'}) }
+        specify { expect(parser.all.name).to eq('foo') }
+
+        context "combined with symbolize keys" do
+          subject(:parser) do
+            Saxerator.parser(xml) do |config|
+              config.adapter = adapter
+              config.strip_namespaces!
+              config.symbolize_keys!
+            end
+          end
+
+          specify { expect(parser.all).to eq({:bar => 'baz'}) }
+        end
+
+        context "for specific namespaces" do
+          let(:xml) do
+            <<-XML.gsub /^ {10}/, ''
           <ns1:foo>
             <ns2:bar>baz</ns2:bar>
             <ns3:bar>biz</ns3:bar>
           </ns1:foo>
-          XML
+            XML
+          end
+          subject(:parser) do
+            Saxerator.parser(xml) do |config|
+              config.adapter = adapter
+              config.strip_namespaces! :ns1, :ns3
+            end
+          end
+
+          specify { expect(parser.all).to eq({'ns2:bar' => 'baz', 'bar' => 'biz'}) }
+          specify { expect(parser.all.name).to eq('foo') }
         end
+      end
+
+    end
+
+    context "configuration with put_attributes_in_hash!" do
+      let(:xml) { '<foo foo="bar"><bar>baz</bar></foo>' }
+
+      subject(:parser) do
+        Saxerator.parser(xml) do |config|
+          config.adapter = adapter
+          config.put_attributes_in_hash!
+        end
+      end
+
+      it "should be able to parse it" do
+        expect(parser.all).to eq({ 'bar' => 'baz', 'foo' => 'bar' })
+      end
+
+      context 'with configured output_type :xml' do
         subject(:parser) do
-          Saxerator.parser(xml) { |config| config.strip_namespaces! :ns1, :ns3 }
+          Saxerator.parser(xml) do |config|
+            config.adapter = adapter
+            config.put_attributes_in_hash!
+            config.output_type = :xml
+          end
         end
 
-        specify { expect(parser.all).to eq({'ns2:bar' => 'baz', 'bar' => 'biz'}) }
-        specify { expect(parser.all.name).to eq('foo') }
-      end
-    end
-
-  end
-
-  context "configuration with put_attributes_in_hash!" do
-    let(:xml) { '<foo foo="bar"><bar>baz</bar></foo>' }
-
-    subject(:parser) do
-      Saxerator.parser(xml) do |config|
-        config.put_attributes_in_hash!
-      end
-    end
-
-    it "should be able to parse it" do
-      expect(parser.all).to eq({ 'bar' => 'baz', 'foo' => 'bar' })
-    end
-
-    context 'with configured output_type :xml' do
-      subject(:parser) do
-        Saxerator.parser(xml) do |config|
-          config.put_attributes_in_hash!
-          config.output_type = :xml
+        context "should raise error with " do
+          specify { expect { parser }.to raise_error(ArgumentError) }
         end
       end
 
-      context "should raise error with " do
-        specify { expect { parser }.to raise_error(ArgumentError) }
-      end
-    end
-
-    context 'with symbolize_keys!' do
-      subject(:parser) do
-        Saxerator.parser(xml) do |config|
-          config.put_attributes_in_hash!
-          config.symbolize_keys!
+      context 'with symbolize_keys!' do
+        subject(:parser) do
+          Saxerator.parser(xml) do |config|
+            config.adapter = adapter
+            config.put_attributes_in_hash!
+            config.symbolize_keys!
+          end
         end
-      end
 
-      it 'will symbolize attribute hash keys' do
-        expect(parser.all.to_hash).to include(:bar => 'baz', :foo => 'bar')
+        it 'will symbolize attribute hash keys' do
+          expect(parser.all.to_hash).to include(:bar => 'baz', :foo => 'bar')
+        end
       end
     end
   end
+end
+
+describe Saxerator do
+  it_behaves_like Saxerator, :ox
+  it_behaves_like Saxerator, :nokogiri
 end

--- a/spec/lib/saxerator_spec.rb
+++ b/spec/lib/saxerator_spec.rb
@@ -58,12 +58,6 @@ RSpec.shared_examples_for Saxerator do |adapter|
           specify { expect(parser.all).to eq('bar' => 'baz') }
         end
 
-        context "with config.output_type = :xml" do
-          let(:output_type) { :xml }
-          specify { expect(parser.all).to be_a Nokogiri::XML::Document }
-          specify { expect(parser.all.to_s).to include '<bar foo="bar">' }
-        end
-
         context "with an invalid config.output_type" do
           let(:output_type) { 'lmao' }
           specify { expect { parser }.to raise_error(ArgumentError) }
@@ -208,4 +202,36 @@ end
 describe Saxerator do
   it_behaves_like Saxerator, :ox
   it_behaves_like Saxerator, :nokogiri
+
+  context 'configuration' do
+    let(:xml) { '<foo><bar foo="bar">baz</bar></foo>' }
+
+    context 'output type' do
+      subject(:parser) do
+        Saxerator.parser(xml) do |config|
+          config.adapter = adapter
+          config.output_type = output_type
+        end
+      end
+
+      context 'ox adapter' do
+        let(:adapter) { :ox }
+
+        context 'with config.output_type = :xml' do
+          let(:output_type) { :xml }
+          specify { expect { parser }.to raise_error(ArgumentError) }
+        end
+      end
+
+      context 'nokogiri adapter' do
+        let(:adapter) { :nokogiri }
+
+        context 'with config.output_type = :xml' do
+          let(:output_type) { :xml }
+          specify { expect(parser.all).to be_a Nokogiri::XML::Document }
+          specify { expect(parser.all.to_s).to include '<bar foo="bar">' }
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,10 @@ if ENV['COVERAGE']
   end
 end
 
-Dir['./spec/support/**/*.rb'].each { |f| require f }
+require 'support/fixture_file'
 
 RSpec.configure do |config|
+  config.example_status_persistence_file_path = "spec/examples.txt"
   config.include FixtureFile
 end
 


### PR DESCRIPTION
@soulcutter I've updated configuration class. Should fix:
> disallow Saxerator::Configuration#output_type = :xml for Ox (or alternately get that to work, but that seems way harder at this point)

Take a look please when you'll find a time.