### PR TITLE
Return an enumerator if no block is given

### DIFF
--- a/lib/saxerator/document_fragment.rb
+++ b/lib/saxerator/document_fragment.rb
@@ -10,6 +10,8 @@ module Saxerator
     end
 
     def each(&block)
+      return to_enum unless block_given?
+
       # Always have to start at the beginning of a File
       @source.rewind if @source.respond_to?(:rewind)
 

--- a/spec/lib/saxerator_spec.rb
+++ b/spec/lib/saxerator_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe Saxerator do
         expect(parser.for_tag(:blurb).first).to eq('one')
         expect(parser.for_tag(:blurb).first).to eq('one')
       end
+
+      it 'call each without block returns enumerator' do
+        enumerator = parser.for_tag(:blurb).each
+        expect(enumerator).to be_an(Enumerator)
+        expect(enumerator.to_a).to eq(%w(one two three))
+      end
     end
 
     context 'with a String argument' do
@@ -33,6 +39,12 @@ RSpec.describe Saxerator do
 
       it 'can parse it' do
         expect(parser.all).to eq('name' => 'Illiterates that can read', 'author' => 'Eunice Diesel')
+      end
+
+      it 'call each without block returns enumerator' do
+        enumerator = parser.for_tag(:name).each
+        expect(enumerator).to be_an(Enumerator)
+        expect(enumerator.to_a).to eq(['Illiterates that can read'])
       end
     end
   end


### PR DESCRIPTION
This is the typical pattern for Enumerable objects, and was an oversight
that it was not already-included here.

See http://ruby-doc.org/core-2.4.1/Object.html#method-i-to_enum