### PR TITLE
Added handling error on XML data structure.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,7 @@ Style/SymbolProc:
 Style/RegexpLiteral:
   Enabled: false
 
-Style/IndentArray:
+Layout/IndentArray:
   Enabled: false
 
 Style/WordArray:
@@ -43,4 +43,7 @@ Metrics/AbcSize:
   Enabled: false
 
 Style/StringLiterals:
+  Enabled: false
+
+Style/GuardClause:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#55](https://github.com/soulcutter/saxerator/issues/55): Ox SAX Parser not Raising Errors (@fanantoxa)
 * [#56](https://github.com/soulcutter/saxerator/issues/56): Implement Oga support (@soulcutter)
 * [#57](https://github.com/soulcutter/saxerator/issues/57): Remove special case for EmptyElement (@soulcutter)
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ group :coverage do
   gem 'simplecov'
 end
 
-gem 'pry', platforms: [:ruby_21, :ruby_22, :ruby_23]
+gem 'pry', platforms: %i[ruby_21 ruby_22 ruby_23 ruby_24]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ for added clarity).
 | `with_attributes(attrs)` | Similar to `with_attribute` except takes an Array or Hash indicating the attributes to match
 
 On any parsing error it'll raise an `Saxerator::ParseException` exception with the message that describe what is wrong on XML document.
+**Warning** Rexml won't raise and error if root elent wasn't closed. (will be fixed on ruby 2.5)
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ for added clarity).
 | `with_attribute(name, value)` | Elements that have an attribute with a given `name` and `value`. If no `value` is given, matches any element with the specified attribute name present
 | `with_attributes(attrs)` | Similar to `with_attribute` except takes an Array or Hash indicating the attributes to match
 
+On any parsing error it'll raise an `Saxerator::ParseException` exception with the message that describe what is wrong on XML document.
+
 Examples
 --------
 ```ruby

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task default: :spec
 namespace :spec do
   desc 'Run specs against all available adapters'
   task :adapters do |_|
-    %w(nokogiri ox rexml oga).each do |adapter|
+    %w[nokogiri ox oga rexml].each do |adapter|
       ENV['SAXERATOR_ADAPTER'] = adapter
       Rake::Task['spec'].invoke
       ::Rake.application['spec'].reenable

--- a/benchmark/benchmark.rb
+++ b/benchmark/benchmark.rb
@@ -9,7 +9,7 @@ unless File.exist?(file)
 end
 file = File.new(file)
 
-ADAPTERS = [:nokogiri, :ox].freeze
+ADAPTERS = %i[nokogiri ox oga rexml].freeze
 
 class SaxeratorBenchmark
   def initialize(file)

--- a/lib/saxerator.rb
+++ b/lib/saxerator.rb
@@ -23,6 +23,9 @@ require 'saxerator/latches/child_of'
 require 'saxerator/latches/with_attributes'
 
 module Saxerator
+  class ParseException < StandardError
+  end
+
   extend self
 
   def parser(xml)

--- a/lib/saxerator/adapters/nokogiri.rb
+++ b/lib/saxerator/adapters/nokogiri.rb
@@ -29,6 +29,10 @@ module Saxerator
         end_element(name)
       end
 
+      def error(message)
+        raise Saxerator::ParseException, message
+      end
+
       private
 
       def strip_namespace(attrs)

--- a/lib/saxerator/adapters/oga.rb
+++ b/lib/saxerator/adapters/oga.rb
@@ -7,8 +7,10 @@ module Saxerator
       extend Forwardable
 
       def self.parse(source, reader)
-        parser = ::Oga::XML::SaxParser.new(new(reader), source)
+        parser = ::Oga::XML::SaxParser.new(new(reader), source, strict: true)
         parser.parse
+      rescue LL::ParserError => message
+        raise Saxerator::ParseException, message
       end
 
       def initialize(reader)
@@ -36,7 +38,7 @@ module Saxerator
         attrs.map { |k, v| [k.gsub(NAMESPACE_MATCHER, ''), v] }
       end
 
-      NAMESPACE_MATCHER = /\A.+:/.freeze
+      NAMESPACE_MATCHER = /\A.+:/
     end
   end
 end

--- a/lib/saxerator/adapters/ox.rb
+++ b/lib/saxerator/adapters/ox.rb
@@ -54,6 +54,10 @@ module Saxerator
 
       alias cdata text
 
+      def error(message, _, _)
+        raise Saxerator::ParseException, message
+      end
+
       private
 
       def reset!

--- a/lib/saxerator/adapters/rexml.rb
+++ b/lib/saxerator/adapters/rexml.rb
@@ -11,6 +11,8 @@ module Saxerator
       def self.parse(source, reader)
         handler = new(reader)
         REXML::Document.parse_stream(source, handler)
+      rescue REXML::ParseException => message
+        raise Saxerator::ParseException, message
       end
 
       def initialize(reader)
@@ -36,7 +38,6 @@ module Saxerator
       def strip_namespace(name)
         name.split(':').last
       end
-
     end
   end
 end

--- a/lib/saxerator/configuration.rb
+++ b/lib/saxerator/configuration.rb
@@ -3,7 +3,7 @@ module Saxerator
     attr_writer :hash_key_generator
     attr_reader :output_type
 
-    ADAPTER_TYPES = [:ox, :nokogiri, :rexml]
+    ADAPTER_TYPES = %i[ox nokogiri rexml oga].freeze
 
     def initialize
       @adapter = :rexml
@@ -39,7 +39,7 @@ module Saxerator
     end
 
     def hash_key_normalizer
-      @hash_key_normalizer ||= -> (x) { x.to_s }
+      @hash_key_normalizer ||= ->(x) { x.to_s }
     end
 
     def hash_key_generator
@@ -47,15 +47,15 @@ module Saxerator
     end
 
     def symbolize_keys!
-      @hash_key_generator = -> (x) { hash_key_normalizer.call(x).to_sym }
+      @hash_key_generator = ->(x) { hash_key_normalizer.call(x).to_sym }
     end
 
     def strip_namespaces!(*namespaces)
       if namespaces.any?
         matching_group = namespaces.join('|')
-        @hash_key_normalizer = -> (x) { x.to_s.gsub(/(#{matching_group}):/, '') }
+        @hash_key_normalizer = ->(x) { x.to_s.gsub(/(#{matching_group}):/, '') }
       else
-        @hash_key_normalizer = -> (x) { x.to_s.gsub(/\w+:/, '') }
+        @hash_key_normalizer = ->(x) { x.to_s.gsub(/\w+:/, '') }
       end
     end
 

--- a/lib/saxerator/latches/child_of.rb
+++ b/lib/saxerator/latches/child_of.rb
@@ -14,7 +14,7 @@ module Saxerator
       def end_element(_)
         return unless depth_within_element > 0
         increment_depth(-1)
-        @depths.pop if @depths[-1] == 0
+        @depths.pop if @depths[-1].zero?
       end
 
       def open?

--- a/lib/saxerator/parser/accumulator.rb
+++ b/lib/saxerator/parser/accumulator.rb
@@ -21,7 +21,7 @@ module Saxerator
       end
 
       def characters(string)
-        @stack[-1].add_node(string) unless string.strip.length == 0
+        @stack[-1].add_node(string) unless string.strip.empty?
       end
 
       def accumulating?

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/spec/lib/builder/hash_builder_spec.rb
+++ b/spec/lib/builder/hash_builder_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'spec_helper'
 
 describe 'Saxerator (default) hash format' do

--- a/spec/lib/builder/xml_builder_spec.rb
+++ b/spec/lib/builder/xml_builder_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'spec_helper'
 
 describe 'Saxerator xml format' do
@@ -12,7 +13,7 @@ describe 'Saxerator xml format' do
 
   it { is_expected.to be_a(REXML::Document) }
   it 'looks like the original document' do
-    expected_xml = '<?xml version=\'1.0\' encoding=\'UTF-8\'?><entry><id>1</id><published>2012-01-01T16:17:00-06:00</published><updated>2012-01-01T16:17:00-06:00</updated><link href="https://example.com/blog/how-to-eat-an-airplane"/><title>How to eat an airplane</title><content type="html">&lt;p&gt;Airplanes are very large — this can present difficulty in digestion.&lt;/p&gt;</content><media:thumbnail url="http://www.gravatar.com/avatar/a9eb6ba22e482b71b266daadf9c9a080?s=80"/><author><name>Soul&lt;utter</name></author><contributor type="primary"><name>Jane Doe</name></contributor><contributor><name>Leviticus Alabaster</name></contributor></entry>'
+    expected_xml = '<?xml version=\'1.0\' encoding=\'UTF-8\'?><entry><id>1</id><published>2012-01-01T16:17:00-06:00</published><updated>2012-01-01T16:17:00-06:00</updated><link href="https://example.com/blog/how-to-eat-an-airplane"/><title>How to eat an airplane</title><content type="html">&lt;p&gt;Airplanes are very large — this can present difficulty in digestion.&lt;/p&gt;</content><media:thumbnail url="http://www.gravatar.com/avatar/a9eb6ba22e482b71b266daadf9c9a080?s=80"/><author><name>Soul&lt;utter</name></author><contributor type="primary"><name>Jane Doe</name></contributor><contributor><name>Leviticus Alabaster</name></contributor></entry>' # rubocop:disable Metrics/LineLength
     expect(entry.to_s).to eq(expected_xml)
   end
 end

--- a/spec/lib/dsl/for_tags_spec.rb
+++ b/spec/lib/dsl/for_tags_spec.rb
@@ -14,7 +14,7 @@ describe 'Saxerator::DSL#for_tags' do
   end
 
   it 'only selects the specified tags' do
-    expect(parser.for_tags(%w(blurb1 blurb3)).inject([], :<<)).to eq(['one', 'three'])
+    expect(parser.for_tags(%w[blurb1 blurb3]).inject([], :<<)).to eq(['one', 'three'])
   end
 
   it 'raises an ArgumentError for a non-Array argument' do

--- a/spec/lib/dsl/with_attributes_spec.rb
+++ b/spec/lib/dsl/with_attributes_spec.rb
@@ -23,7 +23,7 @@ describe 'Saxerator::DSL#with_attributes' do
   end
 
   it 'matches tags which have the specified attributes' do
-    expect(parser.with_attributes(%w(type ridiculous)).inject([], :<<))
+    expect(parser.with_attributes(%w[type ridiculous]).inject([], :<<))
       .to eq(['Leviticus Alabaster', 'Eunice Diesel'])
   end
 

--- a/spec/lib/saxerator_spec.rb
+++ b/spec/lib/saxerator_spec.rb
@@ -54,8 +54,10 @@ RSpec.describe Saxerator do
         eos
       end
 
-      it 'ending node not found' do
-        expect { Saxerator.parser(broken_xml_1).all }.to raise_error(Saxerator::ParseException)
+      unless ENV['SAXERATOR_ADAPTER'] == "rexml"
+        it 'ending node not found' do
+          expect { Saxerator.parser(broken_xml_1).all }.to raise_error(Saxerator::ParseException)
+        end
       end
 
       it 'node in the middle not closed' do

--- a/spec/lib/saxerator_spec.rb
+++ b/spec/lib/saxerator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Saxerator do
       let(:xml) { fixture_file('flat_blurbs.xml') }
 
       it 'can parse it' do
-        expect(parser.all).to eq('blurb' => %w(one two three))
+        expect(parser.all).to eq('blurb' => %w[one two three])
       end
 
       it 'allows multiple operations on the same parser' do
@@ -33,6 +33,33 @@ RSpec.describe Saxerator do
 
       it 'can parse it' do
         expect(parser.all).to eq('name' => 'Illiterates that can read', 'author' => 'Eunice Diesel')
+      end
+    end
+
+    context 'raise exception when ' do
+      let(:broken_xml_1) do
+        <<-eos
+        <book>
+          <name>Illiterates that can read</name>
+          <author>Eunice Diesel</author>
+        eos
+      end
+
+      let(:broken_xml_2) do
+        <<-eos
+        <book>
+          <name>Illiterates that can read
+          <author>Eunice Diesel</author>
+        </book>
+        eos
+      end
+
+      it 'ending node not found' do
+        expect { Saxerator.parser(broken_xml_1).all }.to raise_error(Saxerator::ParseException)
+      end
+
+      it 'node in the middle not closed' do
+        expect { Saxerator.parser(broken_xml_2).all }.to raise_error(Saxerator::ParseException)
       end
     end
   end


### PR DESCRIPTION
Issue: https://github.com/soulcutter/saxerator/issues/55
Added for all except  REXML. 
For REXML it works partly. 

For `<body><item>test</body>` it works good and raise an exception.
But REXML doesn't raise and exception we we have no closing tag like here: `<body><item>test</item>`

@soulcutter I'm not sure what to do here.
Is it OK to leave it like this and update a readme that we'll not getting exeption in this case?
Or wait for response from Ruby devs?

PS Already created a bug here: https://bugs.ruby-lang.org/issues/13636



