### PR TITLE
Child elements mixed with text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - gem install bundler -v 1.12.5
+  - gem install bundler -v 1.16.1
 script: "bundle exec rake spec:adapters"
 language: ruby
 bundler_args: --without coverage --binstubs

--- a/lib/saxerator/builder/array_element.rb
+++ b/lib/saxerator/builder/array_element.rb
@@ -3,10 +3,11 @@ require 'delegate'
 module Saxerator
   module Builder
     class ArrayElement < DelegateClass(Array)
-      attr_accessor :name
+      attr_accessor :name, :attributes
 
-      def initialize(arr = [], name = nil)
+      def initialize(arr = [], name = nil, attributes = nil)
         @name = name
+        @attributes = attributes
         super(arr)
       end
 

--- a/lib/saxerator/builder/hash_builder.rb
+++ b/lib/saxerator/builder/hash_builder.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module Saxerator
   module Builder
     class HashBuilder

--- a/lib/saxerator/builder/hash_builder.rb
+++ b/lib/saxerator/builder/hash_builder.rb
@@ -1,3 +1,4 @@
+require 'pry'
 module Saxerator
   module Builder
     class HashBuilder
@@ -14,14 +15,14 @@ module Saxerator
         @children << node
       end
 
-      def to_s(children: @children)
-        StringElement.new(children.join, @name, @attributes)
+      def to_s
+        StringElement.new(@children.join, @name, @attributes)
       end
 
-      def to_hash(children: @children)
+      def to_hash
         hash = HashElement.new(@name, @attributes)
 
-        children.each do |child|
+        @children.each do |child|
           name = child.name
           element = child.block_variable
 
@@ -37,6 +38,17 @@ module Saxerator
         end
 
         hash
+      end
+
+      def to_array
+        arr = @children.map do |child|
+          if child.kind_of?(String)
+            StringElement.new(child, nil, nil)
+          else
+            child.block_variable
+          end
+        end
+        ArrayElement.new(arr, @name, @attributes)
       end
 
       def add_to_hash_element(hash, name, element)
@@ -55,13 +67,7 @@ module Saxerator
         return to_hash unless @children.any? { |c| c.kind_of?(String) }
         return to_s if @children.size == 1
 
-        @children.map do |child|
-          if child.kind_of?(String)
-            to_s(children: [child])
-          else
-            to_hash(children: [child])
-          end
-        end
+        to_array
       end
 
       def normalize_attributes(attributes)

--- a/lib/saxerator/builder/hash_builder.rb
+++ b/lib/saxerator/builder/hash_builder.rb
@@ -64,7 +64,7 @@ module Saxerator
 
       def block_variable
         return to_hash unless @children.any? { |c| c.kind_of?(String) }
-        return to_s if @children.size == 1
+        return to_s if @children.all? { |c| c.kind_of?(String) }
 
         to_array
       end

--- a/spec/fixtures/mixed_text_with_elements.xml
+++ b/spec/fixtures/mixed_text_with_elements.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description>This is a description.<p> A paragraph within the description.<fig> A figure within the paragraph.</fig></p></description>

--- a/spec/fixtures/mixed_text_with_elements.xml
+++ b/spec/fixtures/mixed_text_with_elements.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<description>This is a description.<p> A paragraph within the description.<fig> A figure within the paragraph.</fig></p></description>
+<description>This is a description.<p id='1'>A paragraph within the description.<fig id='1'> A figure within the paragraph.</fig></p><p id='2'>Another paragraph.</p><p id='3'><fig id='2'> A figure within the paragraph.</fig></p></description>

--- a/spec/lib/builder/hash_builder_spec.rb
+++ b/spec/lib/builder/hash_builder_spec.rb
@@ -82,4 +82,16 @@ describe 'Saxerator (default) hash format' do
       expect(element.name).to eq 'media:thumbnail'
     end
   end
+
+  describe 'Saxerator elements with both text and element children format' do
+    let(:xml){ fixture_file('mixed_text_with_elements.xml') }
+    subject(:description) { Saxerator.parser(xml).for_tag(:description).first }
+
+    specify do
+      expect(description.map(&:class))
+        .to match_array([Saxerator::Builder::StringElement, Saxerator::Builder::HashElement])
+    end
+
+    specify{ expect(subject.first).to eq "This is a description." }
+  end
 end

--- a/spec/lib/builder/hash_builder_spec.rb
+++ b/spec/lib/builder/hash_builder_spec.rb
@@ -89,7 +89,20 @@ describe 'Saxerator (default) hash format' do
 
     specify do
       expect(description.map(&:class))
-        .to match_array([Saxerator::Builder::StringElement, Saxerator::Builder::HashElement])
+        .to match_array([
+          Saxerator::Builder::StringElement,
+          Saxerator::Builder::ArrayElement,
+          Saxerator::Builder::StringElement,
+          Saxerator::Builder::HashElement
+        ])
+    end
+
+    specify do
+      expect(description.last.name).to eq 'p'
+    end
+
+    specify do
+      expect(description.last.attributes).to include('id' => '3')
     end
 
     specify{ expect(subject.first).to eq "This is a description." }


### PR DESCRIPTION
Hello and thank you for this useful gem! I’ve been parsing XML files from a third party source and found that sometimes parent elements can contain children being a combination of text and node elements. Sometimes the text wraps the elements, so the order of the children would matter.  I believe this is both well-formed and valid XML. The issue for me is that Saxerator does not yet handle these cases.

I’ve submitted a PR demonstrating what’s worked for me so far. In particular, I would like to maintain to order of string text in relation to sibling elements. Please let me know if this works for Saxerator. I would be happy to make any adjustments. Thank you!