### PR TITLE
Ensure XmlBuilder uses UTF-8 text with REXML Document

### DIFF
--- a/lib/saxerator/builder/xml_builder.rb
+++ b/lib/saxerator/builder/xml_builder.rb
@@ -13,8 +13,12 @@ module Saxerator
         @text = false
       end
 
+      REXML_ENCODING = 'UTF-8'
       def add_node(node)
-        @text = true if node.is_a? String
+        if node.is_a? String
+          @text = true 
+          node.encode!(REXML_ENCODING) unless node.encoding.name == REXML_ENCODING
+        end
         @children << node
       end
 

--- a/spec/lib/builder/xml_builder_spec.rb
+++ b/spec/lib/builder/xml_builder_spec.rb
@@ -16,4 +16,24 @@ describe 'Saxerator xml format' do
     expected_xml = '<?xml version=\'1.0\' encoding=\'UTF-8\'?><entry><id>1</id><published>2012-01-01T16:17:00-06:00</published><updated>2012-01-01T16:17:00-06:00</updated><link href="https://example.com/blog/how-to-eat-an-airplane"/><title>How to eat an airplane</title><content type="html">&lt;p&gt;Airplanes are very large — this can present difficulty in digestion.&lt;/p&gt;</content><media:thumbnail url="http://www.gravatar.com/avatar/a9eb6ba22e482b71b266daadf9c9a080?s=80"/><author><name>Soul&lt;utter</name></author><contributor type="primary"><name>Jane Doe</name></contributor><contributor><name>Leviticus Alabaster</name></contributor></entry>' # rubocop:disable Metrics/LineLength
     expect(entry.to_s).to eq(expected_xml)
   end
+
+  context 'when XML content is not-UTF-8' do
+    let(:xml) do
+      '<?xml version="1.0" encoding="iso-8859-1"?><feed><entry><title>Norrlandsvägen</title></entry></feed>'.encode('iso-8859-1')
+    end
+
+    let(:title) do
+      Saxerator.parser(StringIO.new(xml)) do |config|
+        config.output_type = :xml
+      end.for_tag(:title).first
+    end
+
+    subject(:text) do
+      title.root.get_text.value
+    end
+
+    it 'REXML text uses UTF-8' do
+      expect(text.encoding.name).to eq('UTF-8')
+    end
+  end
 end


### PR DESCRIPTION
As discussed in this REXML issue: https://github.com/ruby/rexml/issues/85

> REXML supports parsing non-UTF-8 XML but REXML uses UTF-8 string as internal string
> So users need to pass a UTF-8 string to REXML::Element#add_text.

According to the Saxerator adapter, the strings received by `XmlBuilder#add_node` can use the XML source encoding.

As without UTF-8 text, the REXML Document raises error (see REXML issue), the patch changes `XmlBuilder#add_node` to just ensure that the stored child uses UTF-8.